### PR TITLE
finish up movement lerp

### DIFF
--- a/src/actions/moveAction.ts
+++ b/src/actions/moveAction.ts
@@ -3,7 +3,6 @@ import { Point } from "../point";
 import { Action } from "./action";
 import { Actor } from "../entities/actor";
 import { Layer } from "../renderer";
-import { Tile } from "../tile";
 import { MapWorld } from "../map-world";
 
 export class MoveAction implements Action {
@@ -28,8 +27,8 @@ export class MoveAction implements Action {
     // get the direction of movement
     const movementVector = this.targetPos.movementVector(this.actor.position);
     // only move if there is a change in position
-    const shouldMove = movementVector[0] != 0 || movementVector[1] != 0;
-    if (oldPos && shouldMove) {
+    const shouldAnimate = movementVector[0] != 0 || movementVector[1] != 0;
+    if (oldPos) {
       // calculate the tile position of the movement vector
       // and get the screen position of that tile
       // use the terrain layer because it's guaranteed to have a tile at that position
@@ -39,24 +38,27 @@ export class MoveAction implements Action {
         ),
         Layer.TERRAIN
       );
-      // add the animation to the managers queue
-      this.game.animManager.addMoveAnimation(
-        this.actor,
-        MapWorld.coordsToKey(this.targetPos.x, this.targetPos.y),
-        oldPos,
-        newPos
+      if (shouldAnimate) {
+        // add the animation to the managers queue
+        this.game.animManager.addMoveAnimation(
+          this.actor,
+          MapWorld.coordsToKey(this.targetPos.x, this.targetPos.y),
+          oldPos,
+          newPos
+        );
+      }
+
+      // update the position of the sprite in the renderer's cache
+      // keeps the renderer's representation of the map in sync with the game
+      // otherwise, renderer will think sprite is still at old position
+      this.game.renderer.updateSpriteCachePosition(
+        this.actor.position,
+        this.targetPos,
+        Layer.ENTITY
       );
     }
-
-    // update the position of the sprite in the renderer's cache
-    // keeps the renderer's representation of the map in sync with the game
-    // otherwise, renderer will think sprite is still at old position
-    this.game.renderer.updateSpritePosition(
-      this.actor.position,
-      this.targetPos,
-      Layer.ENTITY
-    );
     this.actor.position = new Point(this.targetPos.x, this.targetPos.y);
+
     return Promise.resolve();
   }
 }

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -132,7 +132,6 @@ export class Camera {
         position: target.position,
         target: target,
       };
-      console.log("about to select entity in menu");
       this.ui.components.sideMenu.setEntityTarget(target);
       if (viewportTarget) {
         this.viewportTarget = target;

--- a/src/entities/animal.ts
+++ b/src/entities/animal.ts
@@ -73,7 +73,14 @@ export class Animal implements Actor {
   }
 
   private isGoalReachable(goal: Action): boolean {
-    return !this.game.isMapBlocked(goal.targetPos.x, goal.targetPos.y);
+    const isSelfBlocked = this.game.isOccupiedBySelf(
+      goal.targetPos.x,
+      goal.targetPos.y,
+      this
+    );
+    return (
+      isSelfBlocked || !this.game.isBlocked(goal.targetPos.x, goal.targetPos.y)
+    );
   }
 
   public plan(): void {
@@ -127,11 +134,10 @@ export class Animal implements Actor {
 
   private canPathTo(x: number, y: number): boolean {
     const distanceFromTarget = this.position.manhattanDistance(new Point(x, y));
+    const inRange = distanceFromTarget <= this.range;
     return (
-      distanceFromTarget <= this.range &&
-      !this.game.isMapBlocked(x, y) &&
-      (this.game.isOccupiedBySelf(x, y, this) ||
-        !this.game.isOccupiedByEntity(x, y))
+      inRange &&
+      (!this.game.isBlocked(x, y) || this.game.isOccupiedBySelf(x, y, this))
     );
   }
 

--- a/src/entities/person.ts
+++ b/src/entities/person.ts
@@ -69,7 +69,14 @@ export class Person implements Actor {
   }
 
   private isGoalReachable(goal: Action): boolean {
-    return !this.game.isMapBlocked(goal.targetPos.x, goal.targetPos.y);
+    const isSelfBlocked = this.game.isOccupiedBySelf(
+      goal.targetPos.x,
+      goal.targetPos.y,
+      this
+    );
+    return (
+      isSelfBlocked || !this.game.isBlocked(goal.targetPos.x, goal.targetPos.y)
+    );
   }
 
   public plan(): void {
@@ -123,11 +130,10 @@ export class Person implements Actor {
 
   private canPathTo(x: number, y: number): boolean {
     const distanceFromTarget = this.position.manhattanDistance(new Point(x, y));
+    const inRange = distanceFromTarget <= this.range;
     return (
-      distanceFromTarget <= this.range &&
-      !this.game.isMapBlocked(x, y) &&
-      (this.game.isOccupiedBySelf(x, y, this) ||
-        !this.game.isOccupiedByEntity(x, y))
+      inRange &&
+      (!this.game.isBlocked(x, y) || this.game.isOccupiedBySelf(x, y, this))
     );
   }
 

--- a/src/light-manager.ts
+++ b/src/light-manager.ts
@@ -53,7 +53,7 @@ export class LightManager {
     this.interpolateAmbientLight(false); // initial
     this.interpolateAmbientLight(true); // target
 
-    this.interpolateLightState(1);
+    this.interpolateLightState();
     this.lightingFov = new PreciseShadowcasting(this.lightPasses.bind(this), {
       topology: 8,
     });
@@ -181,19 +181,20 @@ export class LightManager {
     }
   }
 
-  public interpolateLightState(deltaTime: number) {
+  public interpolateLightState() {
+    const progress = this.game.timeManager.turnAnimTimePercent;
     // Interpolate between the current light state and the target light state based on
-    // how much time has passed since the last frame
+    // the progress from start to this.game.options.maxTurnDelay
     this.ambientLight = Color.lerp(
       this.ambientLight,
       this.targetAmbientLight,
-      deltaTime
+      progress
     );
   }
 
   public renderUpdate(deltaTime: number) {
     // Interpolate the light state before computing the lighting
-    this.interpolateLightState(deltaTime);
+    this.interpolateLightState();
     this.lightEmitters.compute(this.lightingCallback.bind(this));
   }
 

--- a/src/manager-animation.ts
+++ b/src/manager-animation.ts
@@ -9,10 +9,8 @@ export interface Animation {
   id: number;
   actor: Actor;
   tileKey: string;
-  action: string;
+  action: "move";
   turnDuration: number;
-  start: number;
-  end: number;
 }
 
 export interface AnimationOptions {
@@ -58,8 +56,6 @@ export class ManagerAnimation {
       newPos: newPos,
       action: "move",
       turnDuration: 1,
-      start: Date.now(),
-      end: Date.now() + this.game.options.maxTurnDelay,
     };
     this.animations.push(animation);
   }
@@ -68,12 +64,10 @@ export class ManagerAnimation {
     const newPos = animation.newPos;
     const oldPos = animation.oldPos;
     if (oldPos && newPos) {
-      // lerp between old and new pos based on time
-      const timeElapsed = Date.now() - animation.start;
-      const timeTotal = animation.end - animation.start;
-      let percent = (timeElapsed / timeTotal) * this.game.timeManager.timeScale;
+      // let percent = (timeElapsed / timeTotal) * this.game.timeManager.timeScale;
+      let percent = this.game.timeManager.turnAnimTimePercent;
 
-      if (percent > 1) {
+      if (percent >= 1) {
         percent = 1;
         this.animations = this.animations.filter((a) => a.id !== animation.id);
       }
@@ -93,7 +87,7 @@ export class ManagerAnimation {
         y = lerpEaseInOut(percent, oldPos[1], newPos[1]);
       }
 
-      this.game.renderer.moveSpriteTransform(
+      this.game.renderer.moveCachedSpriteTransform(
         animation.tileKey,
         Layer.ENTITY,
         x,

--- a/src/manager-web-components.ts
+++ b/src/manager-web-components.ts
@@ -128,7 +128,7 @@ export class ManagerWebComponents {
   public mapEntityToMenuItem(entity: Actor): MenuItem {
     return {
       id: `${entity.id}`,
-      icon: getCachedTile(entity.tile.sprite),
+      icon: getCachedTile(entity.tile.spritePath),
       clickHandler: () => {
         console.log(`clicked on ${entity.id}`);
         this.ui.camera.setPointerTarget(entity.position, entity, true);

--- a/src/map-clouds.ts
+++ b/src/map-clouds.ts
@@ -184,7 +184,7 @@ export class MapClouds {
   }
 
   public renderUpdate(deltaTime: number) {
-    this.interpolateCloudState(deltaTime);
+    this.interpolateCloudState();
   }
 
   private interpolateStrength() {
@@ -224,11 +224,15 @@ export class MapClouds {
     this.sunbeamStrength = Math.round(sunbeamStrength * 1000) / 1000;
   }
 
-  public interpolateCloudState(deltaTime: number) {
+  public interpolateCloudState() {
     let val: number;
     // only iterate through tiles in the viewport
     this.game.userInterface.camera.viewportTiles.forEach((key) => {
-      val = lerp(deltaTime * 10, this.cloudMap[key], this.targetCloudMap[key]);
+      val = lerp(
+        this.game.timeManager.turnAnimTimePercent,
+        this.cloudMap[key],
+        this.targetCloudMap[key]
+      );
       this.cloudMap[key] = val;
     });
   }

--- a/src/map-shadows.ts
+++ b/src/map-shadows.ts
@@ -147,10 +147,7 @@ export class MapShadows {
       this.occlusionMap,
       this.targetOcclusionMap
     );
-    this.interpolateShadowState(
-      this.game.userInterface.camera.viewportTiles,
-      1
-    );
+    this.interpolateShadowState(this.game.userInterface.camera.viewportTiles);
   }
 
   public generateDropoffMaps() {
@@ -255,10 +252,7 @@ export class MapShadows {
 
   public renderUpdate(deltaTime: number) {
     // move towards targetShadowMap from shadowMap every frame
-    this.interpolateShadowState(
-      this.game.userInterface.camera.viewportTiles,
-      deltaTime
-    );
+    this.interpolateShadowState(this.game.userInterface.camera.viewportTiles);
   }
 
   private updateShadowDirection() {
@@ -323,12 +317,14 @@ export class MapShadows {
     this.shadowStrength = Math.round(shadowStrength * 1000) / 1000;
   }
 
-  public interpolateShadowState(keys: string[], deltaTime: number) {
+  public interpolateShadowState(keys: string[]) {
     // smoothly transition between shadowMap and targetShadowMap over time
     let val: number;
+    const progress = this.game.timeManager.turnAnimTimePercent;
+    // console.log(progress);
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
-      val = lerp(deltaTime * 2, this.shadowMap[key], this.targetShadowMap[key]);
+      val = lerp(progress, this.shadowMap[key], this.targetShadowMap[key]);
       this.shadowMap[key] = val;
     }
   }

--- a/src/map-world.ts
+++ b/src/map-world.ts
@@ -1090,7 +1090,7 @@ export class MapWorld {
         this.game.renderer.addToScene(
           MapWorld.keyToPoint(key),
           Layer.TERRAIN,
-          tile.sprite
+          tile.spritePath
         );
       }
     }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -3,9 +3,7 @@ import { Game } from "./game";
 import { Point } from "./point";
 import { Tile } from "./tile";
 import { Color } from "rot-js";
-import { Color as ColorType } from "rot-js/lib/color";
-import { HeightLayer, MapWorld } from "./map-world";
-import { adjustRgbSaturation, rgbToGrayscale } from "./misc-utility";
+import { MapWorld } from "./map-world";
 export enum Layer {
   TERRAIN,
   PLANT,
@@ -143,10 +141,11 @@ export class Renderer {
   }
 
   // update a sprites position in the cache, to be rendered on the next render pass
-  updateSpritePosition(oldPos: Point, newPos: Point, layer: Layer): void {
-    this.spriteCache[layer][`${newPos.x},${newPos.y}`] =
-      this.spriteCache[layer][`${oldPos.x},${oldPos.y}`];
-    this.spriteCache[layer][`${oldPos.x},${oldPos.y}`] = null;
+  updateSpriteCachePosition(oldPos: Point, newPos: Point, layer: Layer): void {
+    const newKey = MapWorld.coordsToKey(newPos.x, newPos.y);
+    const oldKey = MapWorld.coordsToKey(oldPos.x, oldPos.y);
+    this.spriteCache[layer][newKey] = this.spriteCache[layer][oldKey];
+    this.spriteCache[layer][oldKey] = null;
   }
 
   // remove the sprite from the cache and from the scene, immediately
@@ -230,7 +229,7 @@ export class Renderer {
   }
 
   // move a sprites position on the screen, but leave its tile position unchanged
-  moveSpriteTransform(
+  moveCachedSpriteTransform(
     tileKey: string,
     layer: Layer,
     x: number,
@@ -247,7 +246,7 @@ export class Renderer {
     const sprite =
       this.spriteCache[layer][MapWorld.coordsToKey(tilePos.x, tilePos.y)];
     if (sprite) {
-      return [sprite.transform.position.x, sprite.transform.position.y];
+      return [sprite.x, sprite.y];
     }
     return null;
   }

--- a/src/tile.ts
+++ b/src/tile.ts
@@ -8,6 +8,7 @@ import SunIcon from "./shoelace/assets/icons/brightness-high.svg";
 import MagnetIcon from "./shoelace/assets/icons/magnet.svg";
 import HeightIcon from "./shoelace/assets/icons/arrow-up-short.svg";
 import { PointerTarget } from "./camera";
+import { Sprite } from "pixi.js";
 
 // high level types
 export const enum TileType {
@@ -46,7 +47,7 @@ export class Tile {
 
   constructor(
     public readonly type: TileType,
-    public readonly sprite: string,
+    public readonly spritePath: string,
     public readonly color: string,
     public readonly biomeId?: BiomeId
   ) {}

--- a/src/time-manager.ts
+++ b/src/time-manager.ts
@@ -13,8 +13,8 @@ export enum Season {
 export class TimeManager {
   private scheduler: Action;
   public timeScale: number;
-  public turnDelayInMs: number; // how long to wait between turns
   public isPaused: boolean;
+  public turnAnimTimePercent: number;
 
   // time values are in turns
   public maxTimeScale: number;
@@ -38,6 +38,7 @@ export class TimeManager {
   public remainingPhasePercent: number; // how much time left before light phase changes. expressed as decimal
 
   constructor(private game: Game) {
+    this.turnAnimTimePercent = 0;
     this.scheduler = new Action();
     this.isPaused = false;
 
@@ -76,9 +77,18 @@ export class TimeManager {
     return this.scheduler.add(actor, repeat, initialTimeDelay);
   }
 
+  public renderUpdate(deltaTime: number, remainingAnimDelay: number) {
+    this.calculateTurnPercent(remainingAnimDelay);
+  }
+
   public nextOnSchedule(): Actor {
     this.calculateCurrentTime();
     return this.scheduler.next();
+  }
+
+  public calculateTurnPercent(remainingAnimDelay: number): void {
+    const timeTotal = this.game.options.turnAnimDelay;
+    this.turnAnimTimePercent = (timeTotal - remainingAnimDelay) / timeTotal;
   }
 
   public calculateCurrentTime(): void {
@@ -151,5 +161,10 @@ export class TimeManager {
     } else {
       this.isPaused = false;
     }
+  }
+
+  public startTurnAnimation(): void {
+    // reset turn time
+    this.turnAnimTimePercent = 0;
   }
 }

--- a/src/user-interface.ts
+++ b/src/user-interface.ts
@@ -175,7 +175,7 @@ export class UserInterface {
       this.game.renderer.addToScene(
         plant.position,
         Layer.PLANT,
-        plant.tile.sprite
+        plant.tile.spritePath
       );
     }
   }

--- a/src/web-components/tile-info.ts
+++ b/src/web-components/tile-info.ts
@@ -168,7 +168,7 @@ export class TileInfo extends HTMLElement {
 
     if (isActor(target.target)) {
       this.label.textContent = `${target.target.name}`;
-      cachedSprite = getCachedTile(target.target.tile.sprite);
+      cachedSprite = getCachedTile(target.target.tile.spritePath);
       this.avatar.style.transform =
         "translateX(25%) translateY(25%) scale(1.5)";
     }
@@ -176,7 +176,7 @@ export class TileInfo extends HTMLElement {
     if (target.target instanceof Tile) {
       const biome = Biomes.Biomes[target.target.biomeId];
       this.label.textContent = `${biome.name}`;
-      cachedSprite = getCachedTile(target.target.sprite);
+      cachedSprite = getCachedTile(target.target.spritePath);
       this.avatar.style.transform = "translateX(0%) translateY(0%) scale(1)";
     }
 


### PR DESCRIPTION
Rework main game loop- now have a single loop that triggers individual loops at specified rates. Add prop to time manager to hold percent through animation delay- this allows all animations to be tied to this var. Tie lights and other lerp-able transitions to new anim delay var instead of deltaTime. Increase game loop tick rate at higher speeds for smoother gameplay. Known bugs:
   actors sometimes disappear (caused by moving sprite in cache)
   actors sometimes stutter when moving (think it has to do with invalid pathfinding)